### PR TITLE
adding pypi upload and versionning

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,51 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on version tags like v1.0.0, v0.1.2, etc.
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polymathic-aion
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full history for setuptools_scm
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Verify version matches tag
+      run: |
+        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        PACKAGE_VERSION=$(python -c "import setuptools_scm; print(setuptools_scm.get_version())")
+        echo "Tag version: $TAG_VERSION"
+        echo "Package version: $PACKAGE_VERSION"
+        if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+          echo "Version mismatch! Tag: $TAG_VERSION, Package: $PACKAGE_VERSION"
+          exit 1
+        fi
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # This action uses OIDC trusted publishing - no API tokens needed!
+      # Just configure your PyPI project to trust this GitHub repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "setuptools_scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "aion"
-version = "0.0.1"
+dynamic = ["version"]
 description = "AstronomIcal Omnimodal Network"
 requires-python = ">=3.10"
 dependencies = [
@@ -43,3 +43,9 @@ ignore = ["F722"]
 [tool.setuptools.packages.find]
 include = ["aion*"]
 # Only include the 'aion' package and its subpackages
+
+[tool.setuptools_scm]
+# This section configures setuptools_scm
+# It will use git tags to determine version numbers
+# If no tags exist, it will use 0.1.dev0+g<commit_hash>
+fallback_version = "0.1.dev0"


### PR DESCRIPTION
This pull request introduces a workflow for publishing the project to PyPI and integrates `setuptools_scm` for automated version management. The most important changes include adding a GitHub Actions workflow for PyPI publishing, updating the `pyproject.toml` file to use `setuptools_scm`, and configuring version fallback behavior.

### Workflow for PyPI Publishing:
* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bR1-R51): Added a GitHub Actions workflow to publish the project to PyPI when a version tag is pushed. This includes steps for setting up Python, building the package, verifying the version matches the tag, and publishing to PyPI using OIDC trusted publishing.

### Version Management with `setuptools_scm`:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R7): Updated build requirements to include `setuptools_scm` for dynamic versioning based on Git tags. Removed the hardcoded `version` field and replaced it with a `dynamic` version field.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R46-R51): Added a `[tool.setuptools_scm]` section to configure `setuptools_scm`, including a fallback version (`0.1.dev0`) to use when no tags are present.