### PR TITLE
Fix method call for reverse_zeropoint

### DIFF
--- a/aion/codecs/preprocessing/image.py
+++ b/aion/codecs/preprocessing/image.py
@@ -102,6 +102,6 @@ class RescaleToLegacySurvey:
         return image
 
     def backward(self, image, survey):
-        zpscale = self._reverse_zeropoint(27.0) if survey == "HSC" else 1.0
+        zpscale = self.reverse_zeropoint(27.0) if survey == "HSC" else 1.0
         image *= zpscale
         return image


### PR DESCRIPTION
There is a typo for reverse zeropoint method. This fixes that.