### PR TITLE
fix(codecs): correct wavelength padding key in pad_spectrum

### DIFF
--- a/aion/codecs/preprocessing/spectrum.py
+++ b/aion/codecs/preprocessing/spectrum.py
@@ -9,7 +9,7 @@ def pad_spectrum(x: Spectrum) -> Spectrum:
     Note: Each of the sequence attributes (flux, ivar,
           mask, wavelength) should be 2D tensors.
     """
-    padding_values = {"lambda": 99999, "mask": True, "ivar": 0}
+    padding_values = {"wavelength": 99999, "mask": True, "ivar": 0}
 
     for k in ["flux", "ivar", "mask", "wavelength"]:
         setattr(


### PR DESCRIPTION
While using the SDSS spectrum codec, I kept seeing failures consistent with #61 even after #64 landed. Tracing the encode path showed that `pad_spectrum` (introduced in #64) pads `flux`, `ivar`, `mask`, and `wavelength`, but `padding_values` still used the key `"lambda"`. Because the modality field is `wavelength`, those padded positions were filled with `0` instead of the intended `99999` sentinel.

This change updates the dict key to `"wavelength"` so padded wavelength bins match the other fields.
