### PR TITLE
fix(spectrum): use 'wavelength' key in pad_spectrum sentinels

### DIFF
--- a/aion/codecs/preprocessing/spectrum.py
+++ b/aion/codecs/preprocessing/spectrum.py
@@ -9,7 +9,7 @@ def pad_spectrum(x: Spectrum) -> Spectrum:
     Note: Each of the sequence attributes (flux, ivar,
           mask, wavelength) should be 2D tensors.
     """
-    padding_values = {"lambda": 99999, "mask": True, "ivar": 0}
+    padding_values = {"wavelength": 99999, "mask": True, "ivar": 0}
 
     for k in ["flux", "ivar", "mask", "wavelength"]:
         setattr(


### PR DESCRIPTION
## Summary

One-character key-mismatch fix in `aion/codecs/preprocessing/spectrum.py`. `padding_values` declared `"lambda"` as the wavelength sentinel key, but the loop iterates over the `Spectrum` attribute names (`flux`, `ivar`, `mask`, `wavelength`), so the wavelength lookup misses and falls through to the default `0`.

```diff
-    padding_values = {"lambda": 99999, "mask": True, "ivar": 0}
+    padding_values = {"wavelength": 99999, "mask": True, "ivar": 0}
```

## Impact

This makes `pad_spectrum` produce a non-monotonic wavelength array whenever it actually appends elements (i.e. when the input is shorter than `pad_length`):

```
[real_min, …, real_max, 0, 0, …, 0]
```

`LatentSpectralGrid.to_latent` passes this straight into `interp1d`, whose out-of-range mask is:

```python
mask = (xnew < x[..., 0]) | (xnew > x[..., -1])
ynew[mask] = mask_value  # default 0.0
```

With `x[..., -1] == 0`, every position of the latent grid satisfies `xnew > 0`, so the entire latent representation is overwritten with `mask_value`. The encoder then receives an all-zeros input and every spectrum maps to (essentially) the same null embedding.

The upstream test (`tests/codecs/test_spectrum_codec.py`) uses the abstract `Spectrum` base class — which has no `pad_length` ClassVar — so the `hasattr(x, "pad_length")` guard in `_encode` short-circuits and `pad_spectrum` is never exercised in CI. The bug only surfaces in downstream consumers that pass `DESISpectrum` / `SDSSSpectrum` instances of length less than 7808 / 4800 respectively. We hit it in ContrAst with DESI inputs padded to 7800 (so `F.pad` appended 8 elements).

## Why this key

`aion.modalities.Spectrum` declares the field as `wavelength`, not `lambda`. Matching the attribute name is the minimal fix; the `"lambda"` key was dead before this change.

## Test plan

- [ ] Add a regression test that round-trips a `DESISpectrum` of length < 7808 through `pad_spectrum` and asserts the wavelength tail is `99999`, not `0`.
- [ ] Optionally exercise `SpectrumCodec.encode` with a `DESISpectrum` instance to confirm the latent representation is not uniformly zeroed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)